### PR TITLE
Change IPv6 endpoint & Customize error handling

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,21 +1,36 @@
 let endpoint: string;
 let ipv6: boolean;
-let response: {[key: string]: string};
-const ENDPOINT_IPV4 = 'https://api.ipify.org';
-const ENDPOINT_IPV6 = 'https://api6.ipify.org';
+let response: { [key: string]: string };
+const ENDPOINT_IPV4 = "https://api.ipify.org";
+// IPv4/IPv6
+const ENDPOINT_IPV6 = "https://api64.ipify.org";
+const IPv4RegExPattren = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
+
+const isIPv4 = ( ip:string )=> IPv4RegExPattren.test(ip)
 
 const getData = async (endpoint: string) => {
+  /** 
+   if youe use IPv6 endpoint and your public network don't support IPv6 
+   the response well be IPv4
+   @see https://www.ipify.org/
+   */
   const data = await (await fetch(`${endpoint}?format=json`)).json();
   return data;
 };
 
-export async function getIP({ipv6 = false} = {}) {
+export async function getIP({ ipv6 = false } = {}) {
   endpoint = ipv6 ? ENDPOINT_IPV6 : ENDPOINT_IPV4;
   try {
-    response = await getData(endpoint)
+    response = await getData(endpoint);
+    // check response.ip is not IPv6 
+    if (ipv6 === true && isIPv4(response.ip)) {
+      // throw an Error whene the IPv6 is not support
+      throw new Error("Not supported !");
+    }
+    
   } catch (err) {
-    return 'not supported'
+    return "Not supported !";
   }
-
+  
   return response.ip;
 }


### PR DESCRIPTION
hi thies pull request for change IPv6 endpoint to api64.ipify.org for more info you can see the docs from [here ](https://www.ipify.org/)
the response of  the new IPv6 endpoint [``https://api64.ipify.org``](https://api64.ipify.org) will be IPv6 if is support or IPv4 if not

